### PR TITLE
Added script content hashing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_ENV=development
 COPY package*.json ./
 RUN npm install
 
-CMD npx nodemon src/server/app.js
+CMD npm start
 
 FROM dev AS prod
 COPY package*.json ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -5313,6 +5313,16 @@
         }
       }
     },
+    "webpack-manifest-plugin": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-3.1.1.tgz",
+      "integrity": "sha512-r3vL8BBNVtyeNbaFwDQoOWqBd0Gp/Tbzo8Q3YGZDV+IG77gsB9VZry5XKKbfFNFHSmwW+f1z4/w2XPt6wBZJYg==",
+      "dev": true,
+      "requires": {
+        "tapable": "^2.0.0",
+        "webpack-sources": "^2.2.0"
+      }
+    },
     "webpack-merge": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build-static:dev": "webpack --mode development",
     "build-static:prod": "webpack --mode production",
-    "start": "nodemon src/server/app.js"
+    "start": "nodemon src/server/app.js --watch src/server"
   },
   "author": "Alex Kitzberger & Jake Harrington",
   "license": "ISC",
@@ -39,6 +39,7 @@
     "webpack-cli": "^4.7.2"
   },
   "devDependencies": {
-    "nodemon": "^2.0.7"
+    "nodemon": "^2.0.7",
+    "webpack-manifest-plugin": "^3.1.1"
   }
 }

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -13,6 +13,8 @@ const User = require('./models/user')
 const MongoStore = require('connect-mongo')
 const userRoutes = require('./routes/users')
 const flash = require('connect-flash');
+const catchAsync = require('./utils/catchAsync');
+const getManifest = require('./utils/getManifest');
 
 const dbUrl = `mongodb://${process.env.MONGO_HOST}:${process.env.MONGO_PORT}/game-tracker`
 
@@ -88,13 +90,14 @@ app.use((req, res, next) => {
 
 app.use('/', userRoutes);
 
-app.get('/', (req, res) => {
+app.get('/', catchAsync(async (req, res) => {
+    const manifest = await getManifest();
     if(req.user){
-        res.render('home')
+        res.render('home', {manifest})
     } else {
-        res.render('splash')
+        res.render('splash', {manifest})
     }
-})
+}))
 
 app.listen(port, () => {
     console.log(`Serving on port ${port}`)

--- a/src/server/controllers/users.js
+++ b/src/server/controllers/users.js
@@ -1,8 +1,11 @@
-const User = require('../models/user')
+const User = require('../models/user'),
+    catchAsync = require('../utils/catchAsync'),
+    getManifest = require('../utils/getManifest');
 
-module.exports.renderRegister = (req, res) => {
-    res.render('users/register')
-}
+module.exports.renderRegister = catchAsync(async (req, res) => {
+    const manifest = await getManifest();
+    res.render('users/register', {manifest})
+});
 
 module.exports.register = async (req, res, next) => {
     try {
@@ -21,9 +24,10 @@ module.exports.register = async (req, res, next) => {
     }
 }
 
-module.exports.renderLogin = (req, res) => {
-    res.render('users/login');
-}
+module.exports.renderLogin = catchAsync(async (req, res) => {
+    const manifest = await getManifest();
+    res.render('users/login', {manifest});
+});
 
 module.exports.login = (req, res) => {
     req.flash('success', 'Logged in successfully')

--- a/src/server/utils/getManifest.js
+++ b/src/server/utils/getManifest.js
@@ -1,0 +1,17 @@
+const path = require('path'),
+    fs = require('fs').promises;
+
+module.exports = async function getManifest() {
+    const manifestPath = path.join(process.cwd(), 'public/manifest.json');
+
+    if (process.env.NODE_ENV === 'production') {
+        // when requiring a JSON file the object will be cached the first time it's required,
+        // for development this means you'd need to restart the server every time your front
+        // end scripts changed or it'd be sending an old script, but this is
+        // more efficient for production, so we're doing both.
+        return require(manifestPath);
+    }
+    //reload every time for development
+    return JSON.parse((await fs.readFile(manifestPath)).toString());
+}
+

--- a/src/server/views/home.ejs
+++ b/src/server/views/home.ejs
@@ -13,6 +13,6 @@
     <div id="app-root"></div>
     
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
-    <script src="/main.js"></script>
+    <script src="<%= manifest['main.js'] %>"></script>
 </body>
 </html>

--- a/src/server/views/layouts/boilerplate.ejs
+++ b/src/server/views/layouts/boilerplate.ejs
@@ -17,7 +17,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
 
-    <script src="/splash.js"></script>
+    <script src="<%= manifest['splash.js'] %>"></script>
 
 </body>
 

--- a/src/static/components/header.js
+++ b/src/static/components/header.js
@@ -15,8 +15,8 @@ class Header extends Component {
                         </button>
                         <div className="collapse navbar-collapse" id="navbarNavAltMarkup">
                             <ul className="navbar-nav ms-auto mb-2 mb-lg-0">
-                            <li class="nav-item dropdown">
-                                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Account</a>
+                            <li className="nav-item dropdown">
+                                <a className="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Account</a>
                                 <ul className="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDropdown">
                                     <li className="nav-item"><a className="nav-link link-light" href="/logout">Logout</a></li>
                                 </ul>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,16 @@
-const path = require('path');
+const path = require('path'),
+	{WebpackManifestPlugin} = require("webpack-manifest-plugin");
 
 module.exports = {
 	watch: process.argv.includes('development'),
 	entry: {
 		main: './src/static/main.js',
 		splash: './src/static/splash.js'
-	},  
+	},
 	output: {
 		path: path.resolve(__dirname, 'public'),
-		filename: '[name].js'
+		filename: '[name].[contenthash].js',
+		publicPath: ''
 	},
 	module: {
 		rules: [
@@ -23,4 +25,7 @@ module.exports = {
 			}
 		]
 	},
+	plugins: [
+		new WebpackManifestPlugin(),
+	]
 };


### PR DESCRIPTION
When you load a page you want the browser to cache things. I haven't added settings (http headers) to cache things yet (we will do that someday when we switch from express serving assets with `express.static()` to using nginx as a reverse proxy) but this sets us up for proper cache busting.

Cache busting is the term for how you tell the browser scripts need to be loaded again. You watch scripts to be cached all the time so the browser doesn't have to ask your server for them every single time a user loads the page, so you want a really long cache expiration time and some way to bust it. This is the strategy I've been using on my other projects. I installed a new npm package "webpack-manifest-plugin" which will output a `manifest.json` file that maps the original script file names to their new names with a hash of the contents in the file name. That way whenever that hash in the file name changes then the browser will see the new script src in the html (of pages that load after the server updates) and say "oh I don't have main.a7cae40596be273f238b.js cached, better ask the server for it!"

The manifest file looks like `{ "main.js": "main.a7cae40596be273f238b.js" }`, with additional properties for any other webpack entries (like `splash.js`) in there. The content hash is generated automatically by webpack because the webpack config now includes `[contenthash]` in the output file names. The final key to this is that the server must always send the newest content hashed file name! This is where that manifest comes in handy. There's a new `getManifest` utility function used by all of the views that will load the manifest and include it in the page locals. Then in the EJS templates we can get the script file names we want by accessing the desired entry point script from the manifest, so on `home.ejs` the script changed from `src="/main.js"` to `src="<%= manifest['main.js'] %>"` so it'll dynamically insert whatever the newest script name is.

The one final gotcha is the way the manifest is requested. You can use `require()` to load a json file, like the manifest, but `require` will cache the result. So in that case you'd need to restart the server before you would see any of your changes or it'd keep trying to serve you old scripts. I fixed this by only using `require()` for production so it can use the cached manifest, and to manually load and parse the file with `fs` every time the manifest is needed when in development. `getManifest` is an async function so now all the routes that needed it are wrapped in `catchAsync`.

Additionally I fixed the `nodemon` command so it will now ONLY restart the server if a script in `src/server` changes.

I also fixed some react warnings. It didn't like the usage of `class` in the Header component, it wants you to use `className`, an honest mistake!