### PR TITLE
Fix for 500 error when searching

### DIFF
--- a/src/server/controllers/gameList.js
+++ b/src/server/controllers/gameList.js
@@ -26,7 +26,7 @@ module.exports.searchGame = catchAsync(async (req, res) => {
 		take: 10,
 		where: {
 			name: {
-				search: req.body.searchInput.split(' ').join(' & '),
+				search: req.body.searchInput.replace(/[\s\n\t]/g, '_'),
 			},
 			igdbGame: { versionParent: null },
 		},


### PR DESCRIPTION
If you would have tabs, newline, and trailing, leading or consecutive white spaces the server would throw a 500 error because it was trying to search as that character listed earlier.

I changed the way I was mutating the search string to use underscores for all the white spaces, tabs and new lines that may be in the search string since the search will act the same if they are underscores instead.