### PR TITLE
Making To-do's editable and reorder To-do's

### DIFF
--- a/prisma/migrations/20220311185743_changed_index_on_game_name/migration.sql
+++ b/prisma/migrations/20220311185743_changed_index_on_game_name/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "igdbGameName_name_idx";
+
+-- CreateIndex
+CREATE INDEX "igdbGameName_igdbGameId_idx" ON "igdbGameName"("igdbGameId");

--- a/prisma/migrations/20220311203618_removed_indexes_from_game_name/migration.sql
+++ b/prisma/migrations/20220311203618_removed_indexes_from_game_name/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "igdbGameName_igdbGameId_idx";

--- a/prisma/migrations/20220315191721_add_list_position_on_todo_items/migration.sql
+++ b/prisma/migrations/20220315191721_add_list_position_on_todo_items/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ToDoItem" ADD COLUMN     "listPosition" SERIAL NOT NULL;

--- a/prisma/migrations/20220315191948_removed_autoincrement_on_todoitem/migration.sql
+++ b/prisma/migrations/20220315191948_removed_autoincrement_on_todoitem/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "ToDoItem" ALTER COLUMN "listPosition" DROP DEFAULT;
+DROP SEQUENCE "ToDoItem_listPosition_seq";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,14 +35,13 @@ model Game {
   authorId     String
   parentListId String
   igdbGameId   Int
-  listPosition Int
   playStatus   Progress   @default(PlanToPlay)
+  listPosition Int
   author       User       @relation(fields: [authorId], references: [id], onDelete: Cascade)
   igdbGame     igdbGame   @relation(fields: [igdbGameId], references: [id], onDelete: Cascade)
   parentList   GameList   @relation(fields: [parentListId], references: [id], onDelete: Cascade)
   toDoLists    ToDoList[]
 
-  // @@unique([listPosition, parentListId])
   @@unique([igdbGameId, parentListId])
 }
 
@@ -63,6 +62,7 @@ model ToDoItem {
   parentToDoListId String
   authorId         String
   taskText         String
+  listPosition     Int
   author           User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
   parentToDoList   ToDoList @relation(fields: [parentToDoListId], references: [id], onDelete: Cascade)
 }
@@ -92,7 +92,6 @@ model igdbGameName {
   igdbGame   igdbGame @relation(fields: [igdbGameId], references: [id], onDelete: Cascade)
 
   @@unique([altNameId, igdbGameId])
-  @@index([name])
 }
 
 model igdbGameToPlayerPerspective {

--- a/src/server/controllers/game.js
+++ b/src/server/controllers/game.js
@@ -15,7 +15,11 @@ module.exports.getToDoList = catchAsync(async (req, res, next) => {
 					: req.body.parentGameId,
 			},
 			include: {
-				toDoItems: true,
+				toDoItems: {
+					orderBy: {
+						listPosition: 'asc',
+					},
+				},
 			},
 		});
 

--- a/src/server/routes/gameToDo.js
+++ b/src/server/routes/gameToDo.js
@@ -12,8 +12,11 @@ router
 router
 	.route('/toDoItem')
 	.put(gameToDo.newToDoItem)
-	.delete(gameToDo.deleteToDoItem);
+	.delete(gameToDo.deleteToDoItem)
+	.patch(gameToDo.updateToDoItem);
 
 router.route('/updatePlayStatus').put(game.updatePlayStatus);
+
+router.route('/reorderToDoItems').put(gameToDo.reorderToDoItems);
 
 module.exports = router;

--- a/src/static/components/game.js
+++ b/src/static/components/game.js
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import '../styles/game.scss';
 import { Button } from 'react-bootstrap';
 import { Draggable } from 'react-beautiful-dnd';
 
 export default function Game({ game, deleteGame }) {
+	const [dotStyle, setDotStyle] = useState();
+
 	const deleteItem = (e) => {
 		e.preventDefault();
 		const gameToDelete = {
@@ -17,6 +19,17 @@ export default function Game({ game, deleteGame }) {
 		thumbnail = game.igdbGame.cover.replace('thumb', 'micro');
 	}
 
+	const showDots = () => {
+		setDotStyle({ visibility: 'visible' });
+		document.body.addEventListener(
+			'mouseup',
+			() => {
+				setDotStyle({});
+			},
+			{ once: true }
+		);
+	};
+
 	return (
 		<Draggable
 			draggableId={game.id}
@@ -28,11 +41,15 @@ export default function Game({ game, deleteGame }) {
 				<div
 					className="border-bottom border-secondary my-1 pb-1 d-flex align-items-center justify-content-between"
 					{...provided.draggableProps}
-					{...provided.dragHandleProps}
 					ref={provided.innerRef}
 					id="gameDiv"
+					onMouseDown={showDots}
 				>
-					<i className="fa-solid fa-grip-vertical verticalMoveDots" />
+					<i
+						className="fa-solid fa-grip-vertical verticalMoveDots"
+						{...provided.dragHandleProps}
+						style={dotStyle}
+					/>
 
 					<Button
 						variant="link"

--- a/src/static/components/gameList.js
+++ b/src/static/components/gameList.js
@@ -13,7 +13,7 @@ export default function GameList({
 	setGameList,
 	deleteGame,
 	deleteGameList,
-	reorderList,
+	reorderGameList,
 }) {
 	const listName = gameList.listName;
 
@@ -52,16 +52,16 @@ export default function GameList({
 			gameList.games[movedItemIndex]
 		);
 
-		const reorderedList = {
+		const reorderedGameList = {
 			...gameList,
 			games: newListOrder,
 		};
 
 		const newAllGamesList = [...allGameLists];
-		newAllGamesList[listIndex] = reorderedList;
+		newAllGamesList[listIndex] = reorderedGameList;
 		setGameList(newAllGamesList);
 
-		reorderList(reorderedList);
+		reorderGameList(reorderedGameList);
 	};
 
 	return (

--- a/src/static/components/gameListKeeper.js
+++ b/src/static/components/gameListKeeper.js
@@ -9,7 +9,7 @@ export default function GameListKeeper({
 	setGameList,
 	deleteGame,
 	deleteGameList,
-	reorderList,
+	reorderGameList,
 }) {
 	const [gameListForm, setGameListForm] = useState([]);
 
@@ -20,6 +20,7 @@ export default function GameListKeeper({
 	// For new game lists
 	const handleSubmit = (e) => {
 		e.preventDefault();
+
 		const newGameList = {
 			listName: gameListForm,
 		};
@@ -55,7 +56,7 @@ export default function GameListKeeper({
 							key={gameList.id}
 							deleteGame={deleteGame}
 							deleteGameList={deleteGameList}
-							reorderList={reorderList}
+							reorderGameList={reorderGameList}
 						/>
 					);
 				})}

--- a/src/static/components/gamePage.js
+++ b/src/static/components/gamePage.js
@@ -6,7 +6,7 @@ import '../styles/gamePage.scss';
 import GameTime from './gameTime';
 import { Col, Container, Image, Row, Form } from 'react-bootstrap';
 
-export default function GamePage({ game }) {
+export default function GamePage({ gameId }) {
 	const [gameToDoLists, setGameToDoLists] = useState([]);
 
 	const [gamePageInfo, setGamePageInfo] = useState([]);
@@ -33,7 +33,7 @@ export default function GamePage({ game }) {
 		e.preventDefault();
 		const newGameToDoList = {
 			toDoListName: gameToDoListForm,
-			parentGameId: game,
+			parentGameId: gameId,
 		};
 		axios
 			.put('/api/gameToDoLists/', newGameToDoList)
@@ -41,6 +41,13 @@ export default function GamePage({ game }) {
 			.catch((err) => console.error(err));
 
 		setGameToDoListForm('');
+	};
+
+	const reorderToDoList = (newList) => {
+		axios
+			.put('/api/gameToDoLists/reorderToDoItems', newList)
+			.then((res) => setGameToDoLists(res.data))
+			.catch((err) => console.error(err));
 	};
 
 	let cover = '';
@@ -55,7 +62,7 @@ export default function GamePage({ game }) {
 	const fetchGameToDoLists = () => {
 		axios
 			.get('/api/gameToDoLists', {
-				params: { parentGameId: game },
+				params: { parentGameId: gameId },
 			})
 			.then((res) => setGameToDoLists(res.data))
 			.catch((err) => {
@@ -65,7 +72,7 @@ export default function GamePage({ game }) {
 
 	const fetchGamePage = async () => {
 		await axios
-			.get(`/api/games/${game}/getGamePage`)
+			.get(`/api/games/${gameId}/getGamePage`)
 			.then((res) => setGamePageInfo(res.data))
 			.catch((err) => {
 				console.error(err);
@@ -93,6 +100,7 @@ export default function GamePage({ game }) {
 			.delete('/api/gameToDoLists/toDoItem', {
 				data: {
 					toDoItemId: toDoItemToDelete.toDoItemId,
+					parentListId: toDoItemToDelete.parentListId,
 					parentGameId: toDoItemToDelete.parentGameId,
 				},
 			})
@@ -212,12 +220,14 @@ export default function GamePage({ game }) {
 				{gameToDoLists.map((gameToDoList) => {
 					return (
 						<GameToDoList
+							allToDoLists={gameToDoLists}
 							gameToDoList={gameToDoList}
 							setGameToDoLists={setGameToDoLists}
 							key={gameToDoList.id}
 							deleteToDoItem={deleteToDoItem}
 							deleteGameToDoList={deleteGameToDoList}
-							parentGame={game}
+							parentGameId={gameId}
+							reorderToDoList={reorderToDoList}
 						/>
 					);
 				})}

--- a/src/static/components/gameToDoItem.js
+++ b/src/static/components/gameToDoItem.js
@@ -1,33 +1,110 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from 'react-bootstrap';
+import axios from 'axios';
+import '../styles/gameToDoItem.scss';
+import { Draggable } from 'react-beautiful-dnd';
 
-export default function GameToDoItem({ parentGame, toDoItem, deleteToDoItem }) {
+export default function GameToDoItem({
+	parentGameId,
+	parentListId,
+	toDoItem,
+	deleteToDoItem,
+	setGameToDoLists,
+}) {
+	const [toDoText, setToDoText] = useState(toDoItem.taskText);
+
+	const [dotStyle, setDotStyle] = useState();
+
 	const deleteToDo = (e) => {
 		const toDoItemToDelete = {
 			toDoItemId: e.currentTarget.id,
-			parentGameId: parentGame,
+			parentListId: parentListId,
+			parentGameId: parentGameId,
 		};
 		deleteToDoItem(toDoItemToDelete);
 	};
 
-	return (
-		<div className="form-check border-bottom border-secondary pb-1 d-flex justify-content-between">
-			<span
-				id="toDoText"
-				className={`form-check-label px-2 flex-grow-1 my-auto`}
-			>
-				{toDoItem.taskText}
-			</span>
+	const showDots = () => {
+		setDotStyle({ visibility: 'visible' });
+		document.body.addEventListener(
+			'mouseup',
+			() => {
+				setDotStyle({});
+			},
+			{ once: true }
+		);
+	};
 
-			<Button
-				variant="secondary"
-				size="sm"
-				id={toDoItem.id}
-				onClick={deleteToDo}
-			>
-				<span className="visually-hidden">Delete To Do</span>
-				&times;
-			</Button>
-		</div>
+	useEffect(() => {
+		const timeoutId = setTimeout(() => {
+			const editedToDo = {
+				editedToDo: toDoText,
+				toDoItemId: toDoItem.id,
+				parentGameId: parentGameId,
+			};
+			if (toDoText !== toDoItem.taskText) {
+				axios
+					.patch('/api/gameToDoLists/toDoItem', editedToDo)
+					.then((res) => setGameToDoLists(res.data));
+			}
+		}, 500);
+		return () => {
+			clearTimeout(timeoutId);
+		};
+	}, [toDoText]);
+
+	const handleChange = (e) => {
+		setToDoText(e.currentTarget.innerHTML);
+	};
+
+	const preventEnter = (e) => {
+		if (e.key === 'Enter') {
+			e.preventDefault();
+		}
+	};
+
+	return (
+		<Draggable
+			draggableId={toDoItem.id}
+			key={`draggable-${toDoItem.id}`}
+			index={toDoItem.listPosition}
+			disableInteractiveElementBlocking={true}
+		>
+			{(provided) => (
+				<div
+					className="form-check border-bottom border-secondary pb-1 d-flex align-items-center justify-content-between"
+					{...provided.draggableProps}
+					ref={provided.innerRef}
+					id={'toDoDiv'}
+					onMouseDown={showDots}
+				>
+					<i
+						className="fa-solid fa-grip-vertical verticalMoveDots"
+						{...provided.dragHandleProps}
+						style={dotStyle}
+					/>
+					<span
+						id="toDoText"
+						className="form-check-label px-2 flex-grow-1 my-auto"
+						contentEditable
+						suppressContentEditableWarning={true}
+						onBlur={handleChange}
+						onKeyDown={preventEnter}
+					>
+						{toDoItem.taskText}
+					</span>
+
+					<Button
+						variant="secondary"
+						size="sm"
+						id={toDoItem.id}
+						onClick={deleteToDo}
+					>
+						<span className="visually-hidden">Delete To Do</span>
+						&times;
+					</Button>
+				</div>
+			)}
+		</Draggable>
 	);
 }

--- a/src/static/components/gameToDoList.js
+++ b/src/static/components/gameToDoList.js
@@ -2,15 +2,17 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import GameToDoItem from './gameToDoItem';
 import '../styles/gameToDoList.scss';
-import { Col, Button, Form, Dropdown, Row } from 'react-bootstrap';
-import RandomGame from './randomGame';
+import { Col, Form, Dropdown, Row } from 'react-bootstrap';
+import { Droppable, DragDropContext } from 'react-beautiful-dnd';
 
 export default function GameToDoList({
+	allToDoLists,
 	gameToDoList,
 	setGameToDoLists,
 	deleteToDoItem,
 	deleteGameToDoList,
-	parentGame,
+	parentGameId,
+	reorderToDoList,
 }) {
 	const [gameToDoItemForm, setGameToDoItemForm] = useState([]);
 
@@ -28,6 +30,7 @@ export default function GameToDoList({
 			toDoItemText: gameToDoItemForm,
 			parentToDoList: gameToDoList.id,
 			parentGameId: gameToDoList.parentGameId,
+			listLength: gameToDoList.toDoItems.length,
 		};
 		axios
 			.put('/api/gameToDoLists/toDoItem', newToDoItem)
@@ -40,65 +43,123 @@ export default function GameToDoList({
 	const deleteToDoList = (e) => {
 		const toDoListToDelete = {
 			toDoListId: e.currentTarget.id,
-			parentGameId: parentGame,
+			parentGameId: parentGameId,
 		};
 
 		deleteGameToDoList(toDoListToDelete);
 	};
 
+	const onDragEnd = (result) => {
+		const { destination, source, draggableId } = result;
+
+		const listIndex = allToDoLists.findIndex(
+			(x) => x.id === gameToDoList.id
+		);
+
+		const movedItemIndex = gameToDoList.toDoItems.findIndex(
+			(x) => x.id === draggableId
+		);
+
+		if (!destination) {
+			return;
+		}
+		if (
+			destination.droppableId === source.droppableId &&
+			destination.index === source.index
+		) {
+			return;
+		}
+		const newListOrder = Array.from(gameToDoList.toDoItems);
+		newListOrder.splice(source.index, 1);
+		newListOrder.splice(
+			destination.index,
+			0,
+			gameToDoList.toDoItems[movedItemIndex]
+		);
+
+		const reorderedToDoList = {
+			...gameToDoList,
+			toDoItems: newListOrder,
+		};
+
+		const newAllGameToDoList = [...allToDoLists];
+		newAllGameToDoList[listIndex] = reorderedToDoList;
+		setGameToDoLists(newAllGameToDoList);
+
+		reorderToDoList(reorderedToDoList);
+	};
+
 	return (
-		<Col xs={12} sm={6} md={3} className="rounded gamePageToDoList">
-			<div className="py-1">
-				<Row className="listHeader">
-					<Col>
-						<h2 className="text-center">{toDoListName}</h2>
-					</Col>
-					<Col xs="auto">
-						<Dropdown className="pt-2">
-							<Dropdown.Toggle className="fas fa-bars dropdownButton" />
-							<Dropdown.Menu
-								variant="dark"
-								className="listDropdown"
-							>
-								<div>
-									<Dropdown.Item
-										id={gameToDoList.id}
-										onClick={deleteToDoList}
-									>
-										Delete List
-										<span className="visually-hidden">
+		<DragDropContext onDragEnd={onDragEnd}>
+			<Col xs={12} sm={6} md={3} className="rounded gamePageToDoList">
+				<div className="py-1">
+					<Row className="listHeader">
+						<Col>
+							<h2 className="text-center">{toDoListName}</h2>
+						</Col>
+						<Col xs="auto">
+							<Dropdown className="pt-2">
+								<Dropdown.Toggle className="fas fa-bars dropdownButton" />
+								<Dropdown.Menu
+									variant="dark"
+									className="listDropdown"
+								>
+									<div>
+										<Dropdown.Item
+											id={gameToDoList.id}
+											onClick={deleteToDoList}
+										>
 											Delete List
-										</span>
-									</Dropdown.Item>
-								</div>
-							</Dropdown.Menu>
-						</Dropdown>
-					</Col>
-				</Row>
+											<span className="visually-hidden">
+												Delete List
+											</span>
+										</Dropdown.Item>
+									</div>
+								</Dropdown.Menu>
+							</Dropdown>
+						</Col>
+					</Row>
 
-				<Form onSubmit={handleSubmit}>
-					<Form.Control
-						value={gameToDoItemForm}
-						type="text"
-						className="w-100 my-1 rounded px-2 py-1"
-						id="new-toDoList-input"
-						name="new-toDoList-input"
-						onChange={handleChange}
-						placeholder="Add To-Do"
-					/>
-				</Form>
-
-				{toDoItems.map((toDoItem) => {
-					return (
-						<GameToDoItem
-							parentGame={parentGame}
-							toDoItem={toDoItem}
-							key={toDoItem.id}
-							deleteToDoItem={deleteToDoItem}
+					<Form onSubmit={handleSubmit}>
+						<Form.Control
+							value={gameToDoItemForm}
+							type="text"
+							className="w-100 my-1 rounded px-2 py-1"
+							id="new-toDoList-input"
+							name="new-toDoList-input"
+							onChange={handleChange}
+							placeholder="Add To-Do"
+							required
 						/>
-					);
-				})}
-			</div>
-		</Col>
+					</Form>
+
+					<Droppable
+						droppableId={gameToDoList.id}
+						key={`droppable-${gameToDoList.id}`}
+					>
+						{(provided) => (
+							<div
+								ref={provided.innerRef}
+								{...provided.droppableProps}
+							>
+								{toDoItems.map((toDoItem) => {
+									return (
+										<GameToDoItem
+											parentGameId={parentGameId}
+											parentListId={gameToDoList.id}
+											toDoItem={toDoItem}
+											key={toDoItem.id}
+											deleteToDoItem={deleteToDoItem}
+											setGameToDoLists={setGameToDoLists}
+										/>
+									);
+								})}
+								{provided.placeholder}
+							</div>
+						)}
+					</Droppable>
+				</div>
+			</Col>
+		</DragDropContext>
 	);
 }

--- a/src/static/components/home.js
+++ b/src/static/components/home.js
@@ -6,7 +6,7 @@ export default function Home({
 	setGameList,
 	deleteGame,
 	deleteGameList,
-	reorderList,
+	reorderGameList,
 }) {
 	return (
 		<div className="pt-5">
@@ -15,7 +15,7 @@ export default function Home({
 				setGameList={setGameList}
 				deleteGame={deleteGame}
 				deleteGameList={deleteGameList}
-				reorderList={reorderList}
+				reorderGameList={reorderGameList}
 			/>
 		</div>
 	);

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -45,7 +45,7 @@ function App() {
 			.then((res) => setGameList(res.data));
 	};
 
-	const reorderList = (newList) => {
+	const reorderGameList = (newList) => {
 		axios
 			.put('/api/games/reorderGames', newList)
 			.then((res) => setGameList(res.data))
@@ -75,13 +75,13 @@ function App() {
 							setGameList={setGameList}
 							deleteGame={deleteGame}
 							deleteGameList={deleteGameList}
-							reorderList={reorderList}
+							reorderGameList={reorderGameList}
 						/>
 					</Route>
 					<Route
 						path="/games/:id"
 						render={({ match }) => (
-							<GamePage game={match.params.id} />
+							<GamePage gameId={match.params.id} />
 						)}
 					/>
 				</Switch>

--- a/src/static/styles/game.scss
+++ b/src/static/styles/game.scss
@@ -5,12 +5,15 @@
 .gameButton {
 	text-decoration: none;
 	display: inline-flex;
-	background-color: #323f4b;
 	align-items: center;
 }
 
 .verticalMoveDots {
 	color: #f0f4f8;
+}
+
+#gameDiv {
+  background-color: #323f4b;
 }
 
 #gameDiv .verticalMoveDots {

--- a/src/static/styles/gameSearch.scss
+++ b/src/static/styles/gameSearch.scss
@@ -14,7 +14,8 @@
 	color: #f0f4f8;
 	border-color: transparent;
 	outline: none;
-	&:focus {
+    box-shadow: 0 0 0;
+  &:focus {
 		outline: none;
 		border: 1px solid #cc5500;
 	}

--- a/src/static/styles/gameToDoItem.scss
+++ b/src/static/styles/gameToDoItem.scss
@@ -1,3 +1,19 @@
 #toDoText {
-	white-space: break-spaces;
+  white-space: break-spaces;
+}
+
+[contenteditable]:focus {
+  outline: none;
+}
+
+#toDoDiv {
+  background-color: #323f4b;
+}
+
+#toDoDiv .verticalMoveDots {
+  visibility: hidden;
+}
+
+#toDoDiv:hover .verticalMoveDots {
+  visibility: visible;
 }

--- a/src/static/styles/gameToDoList.scss
+++ b/src/static/styles/gameToDoList.scss
@@ -16,8 +16,10 @@
 	color: #f0f4f8;
 	border-color: transparent;
 	outline: none;
-	&:focus {
-		outline: none;
-		border: 1px solid #cc5500;
-	}
+    box-shadow: 0 0 0;
+
+    &:focus {
+          outline: none;
+          border: 1px solid #cc5500;
+      }
 }


### PR DESCRIPTION
Added the ability to edit to-do's using contenteditable on the spans for the to-do's. Removed the outline that it gives it since it was just a finely dotted line that didn't match the style of the rest of the page.

Added the ability to reorder the to-do's in the same vein as the game lists. Renamed some of the functions so it was easier to tell what they are for now that there are 2 different list types that can be reordered.

Changed styling on the input fields to remove the default focused color.

Changed the draggables to only be draggable from the dots on the left hand side of the element.

Tried to fix the game searching index issue as well but opted to just remove the indexing I had done since it appears to be a known working bug that it ignores indexes for FTS and they are currently working on resolving the issue. Once they have it fixed I may have to manually make the index on the DB if they don't add the ability for Prisma to make the index.