### PR TITLE
Changed home in navBar to use react-router

### DIFF
--- a/src/static/components/header.js
+++ b/src/static/components/header.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Container, Nav, Navbar, NavDropdown } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+
 import '../styles/header.scss';
 
 export default function Header() {
@@ -7,7 +9,9 @@ export default function Header() {
 		<header>
 			<Navbar className="navBar" variant="dark" expand="lg">
 				<Container className="m-auto" fluid>
-					<Navbar.Brand href="/">Backlog Ninja</Navbar.Brand>
+					<Link to={'/'} id="navBar-home">
+						<Navbar.Brand>Backlog Ninja</Navbar.Brand>
+					</Link>
 					<Navbar.Toggle />
 					<Navbar.Collapse
 						id="basic-navbar-nav"

--- a/src/static/styles/header.scss
+++ b/src/static/styles/header.scss
@@ -13,3 +13,8 @@
 	font-family: var(--bs-font-sans-serif) !important;
 	font-weight: 400;
 }
+
+#navBar-home {
+  text-decoration: none;
+}
+


### PR DESCRIPTION
The home button in the navBar had been using the href that was part of react-bootstraps NavBar.Brand so it was reloading the whole page. Switched the the NavBar.Brand to be within a react-router link that points to '/' and then removed the href in NavBar.Brand. Also removed the text-decoration on the home link since it underlined it since it is using Link now.